### PR TITLE
Corected a Bolt Arguments Issue in api/db.go

### DIFF
--- a/api/db.go
+++ b/api/db.go
@@ -16,7 +16,7 @@ var (
 
 func init() {
 	var err error
-	db, err = bolt.Open("/tmp/ipxeweb.bolt", 0644)
+	db, err = bolt.Open("/tmp/ipxeweb.bolt", 0644, nil)
 	if err != nil {
 		log.Fatal(err.Error())
 	}


### PR DESCRIPTION
Had an Issue installing ipxed:
/home/setkeh/gocode/src/github.com/kelseyhightower/ipxed/# go install
# github.com/kelseyhightower/ipxed/api

api/db.go:19: not enough arguments in call to bolt.Open

Added "nil" to the Arguments on bolt.open on line 19 of api/db.go and successfully built afterwards.

Hope this helps thanks for the great work :)
